### PR TITLE
Generate regex-free parsing code

### DIFF
--- a/example/argmacros.jl
+++ b/example/argmacros.jl
@@ -1,7 +1,7 @@
 using ArgMacros
 
 function main()
-    @beginarguments begin
+    @inlinearguments begin
         @argumentdefault Int 1 opt1 "-o" "--opt1"
         @argumentdefault Int 2 opt2 "--opt2"
         @argumentflag flag "--flag"

--- a/src/codegen/ast.jl
+++ b/src/codegen/ast.jl
@@ -355,7 +355,6 @@ function read_match(parameters, it, option::Option)
     sym = QuoteNode(cmd_sym(option))
 
     function action(m)
-        println("READ_MATCH: ", typeof(m), " ", m)
         arg = xparse(type, :(String($m[1])))
         return quote
             push!($parameters, $sym => $arg)


### PR DESCRIPTION
*DO NOT MERGE AS IS*

This branch is a demonstration of removing regex completely from the generated parsing code, since I [suggested that](https://discourse.julialang.org/t/ann-argmacros-v0-2-0-flexible-easy-fast-command-line-argument-parsing-in-julia/46566/15?u=zachmatson) before.
Editing your own code is hard, editing someone else's code is harder, and editing someone else's code to edit the code produced by somebody else's code, well, yeah 😅 I just implemented this by adding parallel versions of the existing functions and left the old ones in the codebase, and am not sure if all of the style is quite how you want it.

That being said, consider this a proof of concept and a working point for anyone else who wants to explore this more, because it actually slowed down the `commonicon_zero.jl` benchmark for me compared to the current master. (~605ms -> ~625ms, give or take) I had hope for these results but they didn't end up being great.