### PR TITLE
resolves #135, zero-length args input to cast_args

### DIFF
--- a/src/cast.jl
+++ b/src/cast.jl
@@ -302,6 +302,12 @@ function cast(
 end
 
 function cast_args(doc::JLMD, args::Vector{JLArgument}, line)
+
+    # if no arguments
+    if length(args) == 0
+       return Argument[], nothing
+    end
+
     args = map(args) do each
         Argument(
             string(each.name),

--- a/test/projects/FakePkg/src/FakePkg.jl
+++ b/test/projects/FakePkg/src/FakePkg.jl
@@ -4,6 +4,12 @@ using Test
 using Comonicon
 
 """
+fake noarguments
+
+"""
+@cast noarguments() = @test true
+
+"""
 fake add
 
 # Args

--- a/test/projects/FakePkg/test/runtests.jl
+++ b/test/projects/FakePkg/test/runtests.jl
@@ -11,6 +11,7 @@ using FakePkg
 
     @test FakePkg.command_main(["add", "-h"]) == 0
     @test FakePkg.command_main(["rm", "-h"]) == 0
+    @test FakePkg.command_main(["noarguments", "-h"]) == 0
 
     @test FakePkg.command_main(["rm", "CCC", "-h"]) == 0
     @test FakePkg.command_main(["add", "CCC", "-h"]) == 0


### PR DESCRIPTION
Hopefully this works for you, it seems like it just needs to return an empty vector of expected type and a nothing. Testing this local resolved the issue for me?