### PR TITLE
Fix typo in md_to_string()

### DIFF
--- a/src/markdown.jl
+++ b/src/markdown.jl
@@ -147,7 +147,7 @@ end
 
 function md_to_string(md::Markdown.MD)
     return sprint(md; context = :color => true) do io, x
-        show(io, MIME("text/plain"), x)
+        show(io, MIME"text/plain"(), x)
     end
 end
 


### PR DESCRIPTION
This was causing Markdown doc strings to be improperly formatted in help output