### PR TITLE
add argtypes for better autocompletion

### DIFF
--- a/src/Comonicon.jl
+++ b/src/Comonicon.jl
@@ -15,6 +15,7 @@ export @cast, @main, cmd_error, cmd_exit
 include("compat.jl")
 include("configs.jl")
 include("exceptions.jl")
+include("argtypes.jl")
 include("ast/ast.jl")
 include("codegen/julia.jl")
 include("codegen/zsh.jl")

--- a/src/argtypes.jl
+++ b/src/argtypes.jl
@@ -1,0 +1,70 @@
+module Arg
+
+export FileName, DirName,
+    UserName, Path, Prefix, Suffix,
+    @Prefix_str, @Suffix_str
+
+abstract type ArgType end
+
+struct Path <: ArgType
+    content::String
+end
+
+struct DirName <: ArgType
+    content::String
+end
+
+struct FileName <: ArgType
+    content::String
+end
+
+struct UserName <: ArgType
+    content::String
+end
+
+struct Prefix{name} <: ArgType
+    content::String
+end
+
+struct Suffix{name} <: ArgType
+    content::String
+end
+
+macro Prefix_str(s::String)
+    return Prefix{Symbol(s)}
+end
+
+macro Suffix_str(s::String)
+    return Suffix{Symbol(s)}
+end
+
+Base.show(io::IO, x::Prefix{name}) where name = print(io, "Prefix\"", name, "\"")
+Base.show(io::IO, x::Suffix{name}) where name = print(io, "Suffix\"", name, "\"")
+
+# use rust-like enum instead?
+# @renum ArgType begin
+#     Path
+#     DirName
+#     FileName
+#     UserName
+#     Prefix(name::String)
+#     AnyType(name::String)
+# end
+
+function Base.tryparse(::Type{T}, s::AbstractString) where {T <: ArgType}
+    return T(s)
+end
+
+function Base.tryparse(::Type{Prefix{name}}, s::AbstractString) where {name}
+    prefix = string(name)
+    startswith(s, prefix) && return Prefix{name}(s[length(prefix)+1:end])
+    return
+end
+
+function Base.tryparse(::Type{Suffix{name}}, s::AbstractString) where {name}
+    suffix = string(name)
+    endswith(s, suffix) && return Suffix{name}(s[1:end-length(suffix)])
+    return
+end
+
+end

--- a/src/ast/ast.jl
+++ b/src/ast/ast.jl
@@ -1,6 +1,9 @@
 module AST
 
-export ComoniconExpr, Description, LeafCommand, NodeCommand, Entry, Argument, Option, Flag, print_cmd
+export ComoniconExpr,
+    Description,
+    LeafCommand, NodeCommand,
+    Entry, Argument, Option, Flag, print_cmd
 
 include("types.jl")
 include("printing.jl")

--- a/test/argtype.jl
+++ b/test/argtype.jl
@@ -1,0 +1,8 @@
+using Test
+using Comonicon: Arg
+
+@testset "tryparse(::ArgType, s)" begin
+    @test tryparse(Arg.Path, "random-string").content == "random-string"
+    @test tryparse(Arg.Prefix"file-", "file-content").content == "content"
+    @test tryparse(Arg.Suffix".py", "script.py").content == "script"    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ end
 
 @testset "ast" begin
     include("ast/ast.jl")
+    include("ast/argtype.jl")
 end
 
 @testset "frontend" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,9 +10,12 @@ end
     include("options.jl")
 end
 
+@testset "argtype" begin
+    include("argtype.jl")
+end
+
 @testset "ast" begin
     include("ast/ast.jl")
-    include("ast/argtype.jl")
 end
 
 @testset "frontend" begin


### PR DESCRIPTION
some special types that annotates what kind of string-like input one is expecting, this is really the ideal solution to this since the best way is still to actually have different actual types for path, filename, etc. which is currently missing in Julia, but...