### PR TITLE
Update printing.jl

### DIFF
--- a/src/ast/printing.jl
+++ b/src/ast/printing.jl
@@ -202,7 +202,7 @@ function print_body(io::IO, cmd::Entry, t::Terminal)
     print_body(io, cmd.root, t)
     version_flag = "-V, --version"
     printstyled(io, tab(2), version_flag; color = t.color.dash)
-    print_indent_content(io, "Print version", t, length(version_flag) + 2)
+    print_indent_content(io, "Print version.", t, length(version_flag) + 2)
     println(io)
 end
 
@@ -252,7 +252,7 @@ end
 function print_help(io::IO, t::Terminal)
     help_flag = "-h, --help"
     printstyled(io, tab(2), help_flag; color = t.color.dash)
-    print_indent_content(io, "Print this help message", t, length(help_flag) + 2)
+    print_indent_content(io, "Print this help message.", t, length(help_flag) + 2)
     println(io)
 end
 


### PR DESCRIPTION
End default flag descriptions with `.`, which un-confuses people with narrow terminal, signaling the end of a statement.