### PR TITLE
End version output with newline

### DIFF
--- a/src/codegen/julia.jl
+++ b/src/codegen/julia.jl
@@ -96,7 +96,7 @@ end
 function emit_scan_version(cmd::Entry)
     quote
         if "-V" in ARGS || "--version" in ARGS
-            print($(cmd.version))
+            println($(cmd.version))
             return 0
         end
     end


### PR DESCRIPTION
It is generally expected that command output terminates with a newline.
Without the newline, many shells show an `%`, like so:

![image](https://user-images.githubusercontent.com/20903656/184279400-13347789-efc6-4b25-a473-ba512374aa9d.png)

and I don't think that's desirable.