### PR TITLE
fix setting config from cli

### DIFF
--- a/src/codegen/julia.jl
+++ b/src/codegen/julia.jl
@@ -3,6 +3,7 @@ module JuliaExpr
 using ..AST
 using ..Comonicon: CommandException, CommandExit, _sprint
 using ExproniconLite
+using TOML: TOML
 using Configurations: Configurations
 
 function help_str(x; color = true, width::Int)

--- a/src/codegen/julia.jl
+++ b/src/codegen/julia.jl
@@ -480,9 +480,7 @@ function emit_parse_value(cmd, ctx::EmitContext, type, value)
     elseif type === String # we need to convert SubString to String
         return :(String($value))
     elseif Configurations.is_option(type)
-        return quote
-            $Configurations.from_toml($type, $value)
-        end
+        return :($TOML.parsefile($value))
     else
         @gensym ret
         return quote

--- a/test/codegen/julia/config.jl
+++ b/test/codegen/julia/config.jl
@@ -30,6 +30,10 @@ end
     to_toml("config.toml", opt)
     TestConfigOption.command_main(["--config", "config.toml"])
     TestConfigOption.command_main(["-c", "config.toml"])
+
+    opt = TestConfigOption.OptionB(TestConfigOption.OptionA(1, 1), 2)
+    to_toml("config.toml", opt)
+    TestConfigOption.command_main(["--config", "config.toml", "--config.c=1"])
 end
 
 end


### PR DESCRIPTION
This should fix combining `--config=<path>` with `--config.<property>=<value>`,
the shell auto-completion still won't work with the `dot` operator syntax tho

cc: @avik-pal 