### PR TITLE
bugfix(windows): handle cmd call error

### DIFF
--- a/src/builder/install.jl
+++ b/src/builder/install.jl
@@ -163,6 +163,9 @@ function _entryfile_script_bat(m::Module, options::Configs.Comonicon)
     setlocal
     set JULIA_PROJECT=$(get_scratch!(m, "env"))
     $(join(cmds, " ^\n    "))
+    IF %ERRORLEVEL% NEQ 0 (
+        exit /b %ERRORLEVEL%
+    )
     endlocal
     """
 end

--- a/src/builder/install.jl
+++ b/src/builder/install.jl
@@ -163,9 +163,7 @@ function _entryfile_script_bat(m::Module, options::Configs.Comonicon)
     setlocal
     set JULIA_PROJECT=$(get_scratch!(m, "env"))
     $(join(cmds, " ^\n    "))
-    IF %ERRORLEVEL% NEQ 0 (
-        exit /b %ERRORLEVEL%
-    )
+    if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
     endlocal
     """
 end


### PR DESCRIPTION
The current batch script provided by #241 unconditionally returns 0 because there is an `endlocal` line at the end. This patch fixes it by checking julia exit code and handles it.