### PR TITLE
fix: brief appended to intro by mistake

### DIFF
--- a/src/ast/printing.jl
+++ b/src/ast/printing.jl
@@ -118,10 +118,9 @@ function _print_dash(io::IO, cmd::Union{Option,Flag}, t::Terminal)
 end
 
 function print_content(io::IO, desc::Description, t::Terminal)
-    isnothing(desc.content) || print_within(io, desc.content, t.width, 0)
+    isnothing(desc.content) || (print_within(io, desc.content, t.width, 0); return)
     # if Intro section is empty, use brief description
     isnothing(desc.brief) || print_within(io, desc.brief, t.width, 0)
-    return
 end
 
 function print_cmd(io::IO, cmd::Entry, t::Terminal)


### PR DESCRIPTION
brief has been appended to the end of intro by mistake
this pr fixes this

bug screenshot (see the selected part):
![image](https://github.com/comonicon/Comonicon.jl/assets/5985769/2836313b-5bc3-406c-857b-a650210d5c57)
