### PR TITLE
Load REPL to populate Docs.doc methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Comonicon"
 uuid = "863f3e99-da2a-4334-8734-de3dacbe5542"
 authors = ["Roger-luo and contributors"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"

--- a/src/Comonicon.jl
+++ b/src/Comonicon.jl
@@ -11,6 +11,9 @@ using Markdown
 using ExproniconLite
 using OrderedCollections: OrderedDict
 
+# We only load repl in order to get Base.Docs methods defined, see issue #272
+using REPL: REPL
+
 export @cast, @main, cmd_error, cmd_exit, @lazyload
 
 include("compat.jl")


### PR DESCRIPTION
This function is defined in Base, but the methods used by Comonicon is defined in REPL. Since Julia 1.11, REPL has been moved out of the system image, and these methods are no longer available.

Fixes #272 